### PR TITLE
Use M5Unified.h in sample code of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ platformio lib install M5Stack-Avatar
 ```cpp
 
 #include <M5Unified.h>
-// #include <M5Core2.h> // When using M5Stack Core2
 #include <Avatar.h>
 
 using namespace m5avatar;
@@ -85,7 +84,6 @@ void loop()
 ```cpp
 #include <AquesTalkTTS.h>
 #include <M5Unified.h>
-// #include <M5Core2.h> // When using M5Stack Core2
 #include <Avatar.h>
 #include <tasks/LipSync.h>
 


### PR DESCRIPTION
## Description

Fix sample codes in the README to use `M5Unified.h` as default.

README内のサンプルコードについて、`M5Unified.h`を常に使うよう修正します。

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
