### PR TITLE
Redefine Avatar::getGaze for for backward compatibility & Update setting for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,4 @@
-.pio/
-.pioenvs
-.piolibdeps
-.vscode/
-.vscode/.browse.c_cpp.db*
-.vscode/c_cpp_properties.json
-.vscode/launch.json
-.vscode/settings.json
+### Manual ###
 lib/aqtkpico_esp32
 lib/aquestalk_esp32
 lib/aquestalk-esp32
@@ -13,5 +6,108 @@ src/*.ino
 const.h
 /tmp/
 
-# for macOS
-.DS_Store 
+### gitignore.io
+# Created by https://www.toptal.com/developers/gitignore/api/platformio,visualstudiocode,windows,macos,linux
+# Edit at https://www.toptal.com/developers/gitignore?templates=platformio,visualstudiocode,windows,macos,linux
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### PlatformIO ###
+.pioenvs
+.piolibdeps
+.clang_complete
+.gcc-flags.json
+.pio
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+# !.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/platformio,visualstudiocode,windows,macos,linux

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,4 @@
 {
-    "terminal.integrated.env.linux": {
-        "PATH": "/home/sisikawa/.platformio/penv/bin:/home/sisikawa/.platformio/penv:/home/sisikawa/.cargo/bin:/home/sisikawa/go/bin:/bin:/home/sisikawa/.anyenv/envs/ndenv/shims:/home/sisikawa/.anyenv/envs/ndenv/bin:/home/sisikawa/.anyenv/envs/goenv/shims:/home/sisikawa/.anyenv/envs/goenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/sisikawa/.anyenv/bin",
-        "PLATFORMIO_CALLER": "vscode"
-    },
     "files.associations": {
         "limits": "cpp",
         "array": "cpp",
@@ -43,5 +39,6 @@
         "typeinfo": "cpp",
         "utility": "cpp"
     },
+    "C_Cpp.clang_format_style": "{ BasedOnStyle: Google, IndentWidth: 2 }",
     "cpplint.root": "src"
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,17 +11,23 @@
 [platformio]
 default_envs = m5stack-core
 
-[env]
-platform = espressif32
-framework = arduino
-monitor_speed = 115200
+; [env]
+; platform = espressif32
+; framework = arduino
+; monitor_speed = 115200
 
 [env:m5stack-core]
 board = m5stack-core-esp32
+platform = espressif32
+framework = arduino
+monitor_speed = 115200
 lib_deps = m5stack/M5Unified
 
 [env:m5stack-core-with-aquestalk]
 board = m5stack-core-esp32
+platform = espressif32
+framework = arduino
+monitor_speed = 115200
 lib_deps = m5stack/M5Unified
 build_flags =
   -laquestalk
@@ -29,10 +35,37 @@ build_flags =
 
 [env:m5stack-fire]
 board = m5stack-fire
+platform = espressif32
+framework = arduino
+monitor_speed = 115200
 lib_deps = 
     m5stack/M5Unified
 
 [env:m5stack-core2]
 board = m5stack-core2
+platform = espressif32
+framework = arduino
+monitor_speed = 115200
 lib_deps = 
     m5stack/M5Unified
+
+[env:native]
+platform = native
+lib_deps = m5stack/M5Unified
+build_type = debug
+build_flags = -O0 -xc++ -std=c++14 -lSDL2
+  -I"/usr/local/include/SDL2"                ; for intel mac homebrew SDL2
+  -L"/usr/local/lib"                         ; for intel mac homebrew SDL2
+  -DM5GFX_SHOW_FRAME             ; Display frame image.
+  -DM5GFX_BACK_COLOR=0x222222u   ; Color outside the frame image
+
+[env:native_arm]
+platform = native
+build_type = debug
+lib_deps = m5stack/M5Unified
+build_flags = -O0 -xc++ -std=c++14 -lSDL2
+  -arch arm64                                ; for arm mac
+  -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2" ; for arm mac homebrew SDL2
+  -L"${sysenv.HOMEBREW_PREFIX}/lib"          ; for arm mac homebrew SDL2
+  -DM5GFX_SHOW_FRAME             ; Display frame image.
+  -DM5GFX_BACK_COLOR=0x222222u   ; Color outside the frame image

--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -278,6 +278,11 @@ void Avatar::getLeftGaze(float *vertical, float *horizontal) {
   *horizontal = this->leftGazeH_;
 }
 
+void Avatar::getGaze(float *vertical, float *horizontal){
+  *vertical = 0.5f * this->leftGazeV_ + 0.5f * this->rightGazeV_;
+  *horizontal = 0.5f * this->leftGazeH_ + 0.5f * this->rightGazeH_;
+}
+
 void Avatar::setSpeechText(const char *speechText) {
   this->speechText = String(speechText);
 }

--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -70,15 +70,32 @@ class Avatar {
   void setColorPalette(ColorPalette cp);
   void setFace(Face *face);
   void init(int colorDepth = 1);
+  // expression i/o
   Expression getExpression();
+  void setExpression(Expression exp);
+  // breath i/o
   void setBreath(float f);
   float getBreath();
+  // gaze i/o
   void setRightGaze(float vertical, float horizontal);
   void getRightGaze(float *vertical, float *horizontal);
   void setLeftGaze(float vertical, float horizontal);
   void getLeftGaze(float *vertical, float *horizontal);
-  void setExpression(Expression exp);
-  // eyes functions
+
+  /**
+   * @brief Get the Gaze of Avatar
+   *
+   * [warning] this function return the mean gaze of left gaze & right gaze
+   * This is not the gaze representing avatar's direction of awareness
+   *
+   * @param vertical cache for vertical value. this value will be overwritten
+   * by this method.
+   * @param horizontal cache for horizontal value. this value will be
+   * overwritten by this method.
+   */
+  void getGaze(float *vertical, float *horizontal);
+
+  // eyes open ratio
   void setEyeOpenRatio(float ratio);
   void setRightEyeOpenRatio(float ratio);
   float getRightEyeOpenRatio();


### PR DESCRIPTION
## Description

Redefine `Avatar::getGaze` for backward compatibility.

### Changed Points
-  `Avatar::getGaze` was redefined as a method returning the averaged gaze of left & right one.
- Native environment joined to platform.ini
- .gitignore was updated using [gitignore.io](https://www.toptal.com/developers/gitignore/)
- Auto formatting setting for VSCode joined in .vscode/settings.json. 

## Type of change

- [x] Feature Enhancement
- [x] Breaking Change

